### PR TITLE
Add support for ExpectPlatform.Transformed

### DIFF
--- a/src/main/java/me/shedaniel/architectury/transformer/transformers/RemapInjectables.java
+++ b/src/main/java/me/shedaniel/architectury/transformer/transformers/RemapInjectables.java
@@ -36,7 +36,8 @@ import java.util.List;
 public class RemapInjectables implements TinyRemapperTransformer {
     public static final String expectPlatform = "Lme/shedaniel/architectury/ExpectPlatform;";
     public static final String expectPlatformNew = "Lme/shedaniel/architectury/annotations/ExpectPlatform;";
-    
+    public static final String expectPlatformTransformed = "Lme/shedaniel/architectury/annotations/ExpectPlatform$Transformed;";
+
     @Override
     public List<IMappingProvider> collectMappings() throws Exception {
         if (isInjectInjectables()) {

--- a/src/main/java/me/shedaniel/architectury/transformer/transformers/TransformExpectPlatform.java
+++ b/src/main/java/me/shedaniel/architectury/transformer/transformers/TransformExpectPlatform.java
@@ -152,6 +152,9 @@ public class TransformExpectPlatform implements AssetEditTransformer, ClassEditT
                     int i = returnValue.chars().filter(it -> it != '[').findFirst().getAsInt();
                     addReturn(method.instructions, (char) i);
                     method.maxStack = -1;
+
+                    // Add @ExpectPlatform.Transformed as a marker annotation
+                    method.invisibleAnnotations.add(new AnnotationNode(RemapInjectables.expectPlatformTransformed));
                 }
             }
         }


### PR DESCRIPTION
[Injectables](https://github.com/architectury/architectury-injectables/pull/1) / **Transformer** / [IDEA](https://github.com/architectury/architectury-idea-plugin/pull/1)

Adds the `@ExpectPlatform.Transformed` marker annotation to platform-transformed `@ExpectPlatform` methods. Untested but *should* work.