### PR TITLE
Make generated fake forge mod support any loader version

### DIFF
--- a/src/main/java/me/shedaniel/architectury/transformer/transformers/GenerateFakeForgeMod.java
+++ b/src/main/java/me/shedaniel/architectury/transformer/transformers/GenerateFakeForgeMod.java
@@ -39,7 +39,7 @@ public class GenerateFakeForgeMod extends AbstractFakeMod {
         String fakeModId = generateModId();
         output.addFile("META-INF/mods.toml",
                 "modLoader = \"javafml\"\n" +
-                "loaderVersion = \"[33,)\"\n" +
+                "loaderVersion = \"[1,)\"\n" +
                 "license = \"Generated\"\n" +
                 "[[mods]]\n" +
                 "modId = \"" + fakeModId + "\"\n");


### PR DESCRIPTION
The generated fake forge mod currently requires fml 33 or above. 

To fix this, have the generated mod depend on any fml version `[1, )`.