### PR TITLE
Allow deleting classes from transformers

### DIFF
--- a/src/main/java/dev/architectury/transformer/handler/SimpleTransformerHandler.java
+++ b/src/main/java/dev/architectury/transformer/handler/SimpleTransformerHandler.java
@@ -122,11 +122,13 @@ public class SimpleTransformerHandler implements TransformHandler {
             if (transformer instanceof ClassDeleteTransformer) {
                 ClassDeleteTransformer deleter = (ClassDeleteTransformer) transformer;
                 output.deleteFiles((path, bytes) -> {
-                    ClassReader reader = new ClassReader(bytes);
-                    if ((reader.getAccess() & Opcodes.ACC_MODULE) == 0) {
-                        ClassNode node = new ClassNode(Opcodes.ASM8);
-                        reader.accept(node, ClassReader.EXPAND_FRAMES);
-                        return deleter.shouldDelete(path, node);
+                    if (path.endsWith(".class")) {
+                        ClassReader reader = new ClassReader(bytes);
+                        if ((reader.getAccess() & Opcodes.ACC_MODULE) == 0) {
+                            ClassNode node = new ClassNode(Opcodes.ASM8);
+                            reader.accept(node, ClassReader.EXPAND_FRAMES);
+                            return deleter.shouldDelete(path, node);
+                        }
                     }
                     return false;
                 });

--- a/src/main/java/dev/architectury/transformer/input/BaseFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/BaseFileAccess.java
@@ -1,3 +1,26 @@
+/*
+ * This file is licensed under the MIT License, part of architectury-transformer.
+ * Copyright (c) 2020, 2021 architectury
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package dev.architectury.transformer.input;
 
 import dev.architectury.transformer.util.ClosableChecker;

--- a/src/main/java/dev/architectury/transformer/input/FileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/FileAccess.java
@@ -27,14 +27,17 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 public interface FileAccess extends FileView {
     boolean addFile(String path, byte[] bytes) throws IOException;
-    
+
     byte[] modifyFile(String path, UnaryOperator<byte[]> action) throws IOException;
-    
+
+    boolean deleteFile(String path) throws IOException;
+
     default void modifyFiles(Predicate<String> pathPredicate, BiFunction<String, byte[], byte[]> action) throws IOException {
         try {
             handle(path -> {
@@ -50,16 +53,40 @@ public interface FileAccess extends FileView {
             throw exception.getCause();
         }
     }
-    
+
     default void modifyFiles(BiFunction<String, byte[], byte[]> action) throws IOException {
         modifyFiles(path -> true, action);
     }
-    
+
     default boolean addFile(String path, String text) throws IOException {
         return addFile(path, text.getBytes(StandardCharsets.UTF_8));
     }
-    
+
     default boolean addClass(String path, byte[] bytes) throws IOException {
         return addFile(path + ".class", bytes);
+    }
+
+    default void deleteFiles(BiPredicate<String, byte[]> filePredicate) throws IOException {
+        try {
+            handle((path, bytes) -> {
+                if (filePredicate.test(path, bytes)) {
+                    try {
+                        deleteFile(path);
+                    } catch (IOException exception) {
+                        throw new UncheckedIOException(exception);
+                    }
+                }
+            });
+        } catch (UncheckedIOException exception) {
+            throw exception.getCause();
+        }
+    }
+
+    default void deleteFiles(Predicate<String> pathPredicate) throws IOException {
+        deleteFiles((path, bytes) -> pathPredicate.test(path));
+    }
+
+    default boolean deleteClass(String path) throws IOException {
+        return deleteFile(path + ".class");
     }
 }

--- a/src/main/java/dev/architectury/transformer/input/FileView.java
+++ b/src/main/java/dev/architectury/transformer/input/FileView.java
@@ -38,6 +38,14 @@ public interface FileView extends ClosedIndicator {
     default void handle(Consumer<String> action) throws IOException {
         handle((path, bytes) -> action.accept(path));
     }
+
+    default void handle(Predicate<String> pathPredicate, BiConsumer<String, byte[]> action) throws IOException {
+        handle((path, bytes) -> {
+            if (pathPredicate.test(path)) {
+                action.accept(path, bytes);
+            }
+        });
+    }
     
     void handle(BiConsumer<String, byte[]> action) throws IOException;
     

--- a/src/main/java/dev/architectury/transformer/input/MemoryFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/MemoryFileAccess.java
@@ -1,3 +1,26 @@
+/*
+ * This file is licensed under the MIT License, part of architectury-transformer.
+ * Copyright (c) 2020, 2021 architectury
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package dev.architectury.transformer.input;
 
 import dev.architectury.transformer.Transform;

--- a/src/main/java/dev/architectury/transformer/input/MemoryFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/MemoryFileAccess.java
@@ -62,6 +62,11 @@ public class MemoryFileAccess extends BaseFileAccess {
     protected void write(String path, byte[] bytes) throws IOException {
         data.put(format(path), bytes);
     }
+
+    @Override
+    public boolean deleteFile(String path) throws IOException {
+        return data.remove(format(path)) != null;
+    }
     
     @Override
     protected Stream<String> walk(@Nullable String path) throws IOException {

--- a/src/main/java/dev/architectury/transformer/input/NIOFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/NIOFileAccess.java
@@ -37,7 +37,12 @@ public abstract class NIOFileAccess extends BaseFileAccess {
         }
         Files.write(p, bytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     }
-    
+
+    @Override
+    public boolean deleteFile(String path) throws IOException {
+        return Files.deleteIfExists(resolve(path));
+    }
+
     @Override
     protected Stream<String> walk(@Nullable String path) throws IOException {
         return Files.walk(path == null ? rootPath() : resolve(path))

--- a/src/main/java/dev/architectury/transformer/input/NIOFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/NIOFileAccess.java
@@ -1,3 +1,26 @@
+/*
+ * This file is licensed under the MIT License, part of architectury-transformer.
+ * Copyright (c) 2020, 2021 architectury
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package dev.architectury.transformer.input;
 
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/dev/architectury/transformer/input/NullFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/NullFileAccess.java
@@ -45,7 +45,12 @@ public final class NullFileAccess implements FileAccess {
     public byte[] modifyFile(String path, UnaryOperator<byte[]> action) throws IOException {
         return null;
     }
-    
+
+    @Override
+    public boolean deleteFile(String path) throws IOException {
+        return false;
+    }
+
     @Override
     public void close() throws IOException {
         

--- a/src/main/java/dev/architectury/transformer/input/OpenedFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/OpenedFileAccess.java
@@ -35,7 +35,7 @@ import java.util.function.UnaryOperator;
 
 public class OpenedFileAccess extends ClosableChecker implements FileAccess {
     private final Provider provider;
-    private Lock lock = new ReentrantLock();
+    private final Lock lock = new ReentrantLock();
     private FileAccess fileAccess;
     
     protected OpenedFileAccess(Provider provider) {
@@ -93,7 +93,12 @@ public class OpenedFileAccess extends ClosableChecker implements FileAccess {
     public byte[] modifyFile(String path, UnaryOperator<byte[]> action) throws IOException {
         return getParent().modifyFile(path, action);
     }
-    
+
+    @Override
+    public boolean deleteFile(String path) throws IOException {
+        return getParent().deleteFile(path);
+    }
+
     @Override
     public void close() throws IOException {
         closeAndValidate();

--- a/src/main/java/dev/architectury/transformer/transformers/base/ClassDeleteTransformer.java
+++ b/src/main/java/dev/architectury/transformer/transformers/base/ClassDeleteTransformer.java
@@ -1,3 +1,26 @@
+/*
+ * This file is licensed under the MIT License, part of architectury-transformer.
+ * Copyright (c) 2020, 2021 architectury
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package dev.architectury.transformer.transformers.base;
 
 import dev.architectury.transformer.Transformer;

--- a/src/main/java/dev/architectury/transformer/transformers/base/ClassDeleteTransformer.java
+++ b/src/main/java/dev/architectury/transformer/transformers/base/ClassDeleteTransformer.java
@@ -1,0 +1,8 @@
+package dev.architectury.transformer.transformers.base;
+
+import dev.architectury.transformer.Transformer;
+import org.objectweb.asm.tree.ClassNode;
+
+public interface ClassDeleteTransformer extends Transformer {
+    boolean shouldDelete(String name, ClassNode node);
+}

--- a/src/main/java/dev/architectury/transformer/util/Logger.java
+++ b/src/main/java/dev/architectury/transformer/util/Logger.java
@@ -86,7 +86,7 @@ public class Logger {
         debug(String.format(str, args));
     }
     
-    private static boolean isVerbose() {
+    public static boolean isVerbose() {
         if (verbose == null) {
             verbose = System.getProperty(BuiltinProperties.VERBOSE, "false").equals("true");
         }


### PR DESCRIPTION
This can be useful for a couple of reasons:
* Removing redundant class files between common / platform code (not ideal)
* Removing unnecessary template files from the shadowed common code

I have tested these changes using a modified version of the Gradle plugin to support the new refactor for 5.0. I can confirm that everything is working as expected, The only downside of course is that you can't remove classes _after_ they've been loaded. Only before.

An alternative solution is to not ignore when the `ClassEditTransformer` returns `null` and instead remove the file. I am of course open to discussion on this issue and can make any changes needed to meet your expectations.