### PR TITLE
Fix usernames with special characters like spaces

### DIFF
--- a/src/runtime/java/dev/architectury/transformer/TransformerRuntime.java
+++ b/src/runtime/java/dev/architectury/transformer/TransformerRuntime.java
@@ -293,7 +293,7 @@ public class TransformerRuntime {
         // Java 9 and above
         return url -> {
             try {
-                TransformerAgent.getInstrumentation().appendToSystemClassLoaderSearch(new JarFile(url.getFile()));
+                TransformerAgent.getInstrumentation().appendToSystemClassLoaderSearch(new JarFile(new File(url.toURI())));
             } catch (Throwable throwable) {
                 throw new RuntimeException(throwable);
             }


### PR DESCRIPTION
I remember that this worked once. Most likely in 1.16.5 since I was using Java 8 back then and, thus, the Transformer used the approach using the `URLClassLoader`.
This is a proper fix for this problem: https://discord.com/channels/792699517631594506/813076934740934665/928971864137670686