### PR TITLE
Updated to latest Gradle release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "eclipse"
     id "maven-publish"
     id "com.github.johnrengelman.shadow" version "5.0.0"
-    id "org.cadixdev.licenser" version "0.5.0"
+    id "org.cadixdev.licenser" version "0.6.1"
 }
 
 group "dev.architectury"
@@ -20,7 +20,11 @@ if (!isSnapshot) {
 
 logger.lifecycle(":building architectury transformer v${version}")
 
-sourceCompatibility = targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 repositories {
     maven { url "https://maven.architectury.dev/" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Changes:
- Updated Gradle to `7.6` (supports Java 17)
- Updated Gradle plugin `org.cadixdev.licenser` to lastest `0.6.1` as the old one doesn't work with the new version of Gradle
- Changed `sourceCompatibility = targetCompatibility = 1.8` to [Java toolchains](https://docs.gradle.org/current/userguide/toolchains.html) as it is the modern API to compile Java using a specific java version