### PR TITLE
Fixed unsafe property reading

### DIFF
--- a/src/main/java/dev/architectury/transformer/handler/ThreadLockedTransformHandler.java
+++ b/src/main/java/dev/architectury/transformer/handler/ThreadLockedTransformHandler.java
@@ -25,6 +25,7 @@ package dev.architectury.transformer.handler;
 
 import dev.architectury.transformer.Transformer;
 import dev.architectury.transformer.input.FileAccess;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 
 import java.io.IOException;
 import java.util.List;
@@ -61,5 +62,10 @@ public class ThreadLockedTransformHandler implements TransformHandler {
         } finally {
             lock.unlock();
         }
+    }
+
+    @Override
+    public TransformerContext getContext() {
+        return parent.getContext();
     }
 }

--- a/src/main/java/dev/architectury/transformer/handler/TinyRemapperPreparedTransformerHandler.java
+++ b/src/main/java/dev/architectury/transformer/handler/TinyRemapperPreparedTransformerHandler.java
@@ -37,16 +37,16 @@ public class TinyRemapperPreparedTransformerHandler extends SimpleTransformerHan
     
     public TinyRemapperPreparedTransformerHandler(ReadClasspathProvider classpath, TransformerContext context, boolean nested) throws Exception {
         super(classpath, context, nested);
-        prepare();
+        prepare(context);
     }
     
-    private void prepare() throws Exception {
-        Logger.debug("Preparing tiny remapper prepared transformer: " + getClass().getName());
+    private void prepare(TransformerContext context) throws Exception {
+        context.getLogger().debug("Preparing tiny remapper prepared transformer: " + getClass().getName());
         remapper = TinyRemapper.newRemapper()
                 .skipConflictsChecking(true)
                 .cacheMappings(true)
                 .skipPropagate(true)
-                .logger(Logger::info)
+                .logger((str) -> context.getLogger().info(str))
                 .logUnknownInvokeDynamic(false)
                 .threads(Runtime.getRuntime().availableProcessors())
                 .build();
@@ -56,16 +56,16 @@ public class TinyRemapperPreparedTransformerHandler extends SimpleTransformerHan
     }
     
     @Override
-    public TinyRemapper getRemapper(Set<IMappingProvider> providers) throws Exception {
+    public TinyRemapper getRemapper(Set<IMappingProvider> providers) {
         remapper.replaceMappings(providers);
         if (remapper.isMappingsDirty()) {
-            Logger.debug("Remapping with Dirty Mappings...");
+            context.getLogger().debug("Remapping with Dirty Mappings...");
         }
         return remapper;
     }
     
     @Override
-    protected void closeRemapper(TinyRemapper remapper) throws Exception {
+    protected void closeRemapper(TinyRemapper remapper) {
         remapper.removeInput();
     }
     

--- a/src/main/java/dev/architectury/transformer/handler/TransformHandler.java
+++ b/src/main/java/dev/architectury/transformer/handler/TransformHandler.java
@@ -25,11 +25,14 @@ package dev.architectury.transformer.handler;
 
 import dev.architectury.transformer.Transformer;
 import dev.architectury.transformer.input.FileAccess;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 
 import java.io.Closeable;
 import java.util.List;
 
 public interface TransformHandler extends Closeable {
+    TransformerContext getContext();
+
     default TransformHandler asThreadLocked() {
         return new ThreadLockedTransformHandler(this);
     }

--- a/src/main/java/dev/architectury/transformer/input/FileView.java
+++ b/src/main/java/dev/architectury/transformer/input/FileView.java
@@ -61,7 +61,7 @@ public interface FileView extends ClosedIndicator {
                 try {
                     if (pathPredicate.test(path)) {
                         if (!output.addFile(path, bytes)) {
-                            Logger.debug("Failed to copy %s from %s to %s", path, this, output);
+                            Logger.getDefaultLogger().debug("Failed to copy %s from %s to %s", path, this, output);
                         }
                     }
                 } catch (IOException exception) {

--- a/src/main/java/dev/architectury/transformer/input/JarFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/JarFileAccess.java
@@ -35,11 +35,13 @@ import java.util.WeakHashMap;
 
 public class JarFileAccess extends NIOFileAccess {
     private static final WeakHashMap<Path, JarFileAccess> INTERFACES = new WeakHashMap<>();
+    private final Logger logger;
     protected final Path path;
     private FileSystemReference fs;
     
-    protected JarFileAccess(Path path) {
+    protected JarFileAccess(Logger logger, Path path) {
         super(true);
+        this.logger = logger;
         this.path = path;
         
         try {
@@ -49,7 +51,7 @@ public class JarFileAccess extends NIOFileAccess {
         }
     }
     
-    public static JarFileAccess of(Path root) throws IOException {
+    public static JarFileAccess of(Logger logger, Path root) throws IOException {
         synchronized (INTERFACES) {
             if (INTERFACES.containsKey(root)) {
                 return INTERFACES.get(root);
@@ -61,7 +63,7 @@ public class JarFileAccess extends NIOFileAccess {
                 }
             }
             
-            JarFileAccess outputInterface = new JarFileAccess(root);
+            JarFileAccess outputInterface = new JarFileAccess(logger, root);
             INTERFACES.put(root, outputInterface);
             return outputInterface;
         }
@@ -76,7 +78,7 @@ public class JarFileAccess extends NIOFileAccess {
     public void close() throws IOException {
         super.close();
         if (fs.closeIfPossible()) {
-            Logger.debug("Closed File Systems for " + path);
+            logger.debug("Closed File Systems for " + path);
         }
         INTERFACES.remove(path, this);
     }

--- a/src/main/java/dev/architectury/transformer/input/OpenedFileAccess.java
+++ b/src/main/java/dev/architectury/transformer/input/OpenedFileAccess.java
@@ -24,6 +24,7 @@
 package dev.architectury.transformer.input;
 
 import dev.architectury.transformer.util.ClosableChecker;
+import dev.architectury.transformer.util.Logger;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -51,8 +52,8 @@ public class OpenedFileAccess extends ClosableChecker implements ForwardingFileA
         return new OpenedFileAccess(provider);
     }
     
-    public static OpenedFileAccess ofJar(Path path) {
-        return new OpenedFileAccess(() -> new JarFileAccess(path), path.toString());
+    public static OpenedFileAccess ofJar(Logger logger, Path path) {
+        return new OpenedFileAccess(() -> new JarFileAccess(logger, path), path.toString());
     }
     
     public static OpenedFileAccess ofDirectory(Path path) {

--- a/src/main/java/dev/architectury/transformer/transformers/BuiltinProperties.java
+++ b/src/main/java/dev/architectury/transformer/transformers/BuiltinProperties.java
@@ -35,4 +35,18 @@ public class BuiltinProperties {
     public static final String REFMAP_NAME = "architectury.refmap.name";
     public static final String MCMETA_VERSION = "architectury.mcmeta.version";
     public static final String PLATFORM_NAME = "architectury.platform.name";
+
+    public static final String[] KEYS = new String[]{
+        VERBOSE,
+        DEBUG_OUTPUT,
+        LOCATION,
+        MIXIN_MAPPINGS,
+        INJECT_INJECTABLES,
+        UNIQUE_IDENTIFIER,
+        COMPILE_CLASSPATH,
+        MAPPINGS_WITH_SRG,
+        REFMAP_NAME,
+        MCMETA_VERSION,
+        PLATFORM_NAME
+    };
 }

--- a/src/main/java/dev/architectury/transformer/transformers/ClasspathProvider.java
+++ b/src/main/java/dev/architectury/transformer/transformers/ClasspathProvider.java
@@ -23,20 +23,19 @@
 
 package dev.architectury.transformer.transformers;
 
-import dev.architectury.transformer.Transform;
 import dev.architectury.transformer.util.Logger;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 @FunctionalInterface
 public interface ClasspathProvider {
-    static ClasspathProvider fromProperties() {
-        return () -> Stream.of(Transform.getClasspath())
+    static ClasspathProvider fromProperties(String classPaths) {
+        return () -> Arrays.stream(classPaths.split(File.pathSeparator))
                 .map(Paths::get)
                 .filter(Files::exists)
                 .toArray(Path[]::new);
@@ -58,12 +57,12 @@ public interface ClasspathProvider {
                 .toArray(Path[]::new);
     }
     
-    default ClasspathProvider logging() {
+    default ClasspathProvider logging(Logger logger) {
         return () -> {
             Path[] paths = provide();
-            Logger.debug("Provided " + paths.length + " classpath jar(s):");
+            logger.debug("Provided " + paths.length + " classpath jar(s):");
             for (Path path : paths) {
-                Logger.debug(" - " + path.toString());
+                logger.debug(" - " + path.toString());
             }
             return paths;
         };

--- a/src/main/java/dev/architectury/transformer/transformers/GenerateFakeForgeMod.java
+++ b/src/main/java/dev/architectury/transformer/transformers/GenerateFakeForgeMod.java
@@ -44,7 +44,7 @@ public class GenerateFakeForgeMod extends AbstractFakeMod {
                 "[[mods]]\n" +
                 "modId = \"" + fakeModId + "\"\n");
         output.addFile("pack.mcmeta",
-                "{\"pack\":{\"description\":\"Generated\",\"pack_format\":" + System.getProperty(BuiltinProperties.MCMETA_VERSION, "4") + "}}");
+                "{\"pack\":{\"description\":\"Generated\",\"pack_format\":" + context.getProperty(BuiltinProperties.MCMETA_VERSION, "4") + "}}");
         output.addFile("generated" + fakeModId + "/" + fakeModId + ".class", generateClass(fakeModId));
     }
     

--- a/src/main/java/dev/architectury/transformer/transformers/RemapInjectables.java
+++ b/src/main/java/dev/architectury/transformer/transformers/RemapInjectables.java
@@ -27,6 +27,7 @@ import com.google.common.base.MoreObjects;
 import com.google.gson.JsonObject;
 import dev.architectury.tinyremapper.IMappingProvider;
 import dev.architectury.transformer.transformers.base.TinyRemapperTransformer;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 
 import java.io.File;
 import java.util.Collections;
@@ -51,27 +52,27 @@ public class RemapInjectables implements TinyRemapperTransformer {
     }
     
     @Override
-    public List<IMappingProvider> collectMappings() throws Exception {
-        if (isInjectInjectables()) {
+    public List<IMappingProvider> collectMappings(TransformerContext context) {
+        if (isInjectInjectables(context)) {
             return Collections.singletonList(sink -> {
                 sink.acceptClass(
                         "dev/architectury/injectables/targets/ArchitecturyTarget",
-                        MoreObjects.firstNonNull(uniqueIdentifier, getUniqueIdentifier()) + "/PlatformMethods"
+                        MoreObjects.firstNonNull(uniqueIdentifier, getUniqueIdentifier(context)) + "/PlatformMethods"
                 );
             });
         }
         return Collections.emptyList();
     }
     
-    public static String getUniqueIdentifier() {
-        return System.getProperty(BuiltinProperties.UNIQUE_IDENTIFIER);
+    public static String getUniqueIdentifier(TransformerContext context) {
+        return context.getProperty(BuiltinProperties.UNIQUE_IDENTIFIER);
     }
     
-    public static boolean isInjectInjectables() {
-        return System.getProperty(BuiltinProperties.INJECT_INJECTABLES, "true").equals("true");
+    public static boolean isInjectInjectables(TransformerContext context) {
+        return context.getProperty(BuiltinProperties.INJECT_INJECTABLES, "true").equals("true");
     }
     
-    public static String[] getClasspath() {
-        return System.getProperty(BuiltinProperties.COMPILE_CLASSPATH, "true").split(File.pathSeparator);
+    public static String[] getClasspath(TransformerContext context) {
+        return context.getProperty(BuiltinProperties.COMPILE_CLASSPATH, "true").split(File.pathSeparator);
     }
 }

--- a/src/main/java/dev/architectury/transformer/transformers/RemapMixinVariables.java
+++ b/src/main/java/dev/architectury/transformer/transformers/RemapMixinVariables.java
@@ -26,7 +26,7 @@ package dev.architectury.transformer.transformers;
 import dev.architectury.tinyremapper.IMappingProvider;
 import dev.architectury.tinyremapper.TinyUtils;
 import dev.architectury.transformer.transformers.base.TinyRemapperTransformer;
-import dev.architectury.transformer.util.Logger;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -36,15 +36,15 @@ import java.util.List;
 import java.util.Map;
 
 public class RemapMixinVariables implements TinyRemapperTransformer {
-    private Map<String, IMappingProvider> mixinMappingCache = new HashMap<>();
+    private final Map<String, IMappingProvider> mixinMappingCache = new HashMap<>();
     
     @Override
-    public List<IMappingProvider> collectMappings() throws Exception {
+    public List<IMappingProvider> collectMappings(TransformerContext context) throws Exception {
         List<IMappingProvider> providers = new ArrayList<>();
-        for (String path : System.getProperty(BuiltinProperties.MIXIN_MAPPINGS).split(File.pathSeparator)) {
+        for (String path : context.getProperty(BuiltinProperties.MIXIN_MAPPINGS).split(File.pathSeparator)) {
             File mixinMapFile = Paths.get(path).toFile();
             if (mixinMapFile.exists()) {
-                Logger.debug("Reading mixin mappings file: " + mixinMapFile.getAbsolutePath());
+                context.getLogger().debug("Reading mixin mappings file: " + mixinMapFile.getAbsolutePath());
                 providers.add(mixinMappingCache.computeIfAbsent(path, p ->
                         TinyUtils.createTinyMappingProvider(mixinMapFile.toPath(), "named", "intermediary"))
                 );

--- a/src/main/java/dev/architectury/transformer/transformers/RuntimeMixinRefmapDetector.java
+++ b/src/main/java/dev/architectury/transformer/transformers/RuntimeMixinRefmapDetector.java
@@ -42,7 +42,7 @@ public class RuntimeMixinRefmapDetector implements AssetEditTransformer {
         output.handle((path, bytes) -> {
             String trimmedPath = Transform.trimSlashes(path);
             if (trimmedPath.endsWith(".json") && !trimmedPath.contains("/") && !trimmedPath.contains("\\")) {
-                Logger.debug("Checking whether " + path + " is a mixin config.");
+                context.getLogger().debug("Checking whether " + path + " is a mixin config.");
                 try (InputStreamReader reader = new InputStreamReader(new ByteArrayInputStream(bytes))) {
                     JsonObject json = gson.fromJson(reader, JsonObject.class);
                     if (json != null) {
@@ -50,7 +50,7 @@ public class RuntimeMixinRefmapDetector implements AssetEditTransformer {
                         boolean hasClient = json.has("client") && json.get("client").isJsonArray();
                         boolean hasServer = json.has("server") && json.get("server").isJsonArray();
                         if (json.has("package") && json.has("refmap") && (hasMixins || hasClient || hasServer)) {
-                            Logger.error("Mixin Config [%s] contains 'refmap', please remove it so it works in development environment!", trimmedPath);
+                            context.getLogger().error("Mixin Config [%s] contains 'refmap', please remove it so it works in development environment!", trimmedPath);
                         }
                     }
                 } catch (Exception ignored) {

--- a/src/main/java/dev/architectury/transformer/transformers/TransformForgeAnnotations.java
+++ b/src/main/java/dev/architectury/transformer/transformers/TransformForgeAnnotations.java
@@ -24,6 +24,7 @@
 package dev.architectury.transformer.transformers;
 
 import dev.architectury.transformer.transformers.base.ClassEditTransformer;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
 
@@ -47,7 +48,7 @@ public class TransformForgeAnnotations implements ClassEditTransformer {
     private static final String ONLY_IN = "net/minecraftforge/api/distmarker/OnlyIn";
     
     @Override
-    public ClassNode doEdit(String name, ClassNode node) {
+    public ClassNode doEdit(TransformerContext context, String name, ClassNode node) {
         if ((node.access & Opcodes.ACC_INTERFACE) == 0) {
             if (node.visibleAnnotations != null && node.visibleAnnotations.stream().anyMatch(
                     annotation -> Objects.equals(annotation.desc, FORGE_EVENT) || Objects.equals(annotation.desc, FORGE_EVENT_CANCELLABLE)

--- a/src/main/java/dev/architectury/transformer/transformers/TransformPlatformOnly.java
+++ b/src/main/java/dev/architectury/transformer/transformers/TransformPlatformOnly.java
@@ -24,6 +24,7 @@
 package dev.architectury.transformer.transformers;
 
 import dev.architectury.transformer.transformers.base.ClassEditTransformer;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 import dev.architectury.transformer.util.Logger;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -36,10 +37,10 @@ import java.util.Optional;
 
 public class TransformPlatformOnly implements ClassEditTransformer {
     @Override
-    public ClassNode doEdit(String name, ClassNode node) {
-        String platform = System.getProperty(BuiltinProperties.PLATFORM_NAME);
+    public ClassNode doEdit(TransformerContext context, String name, ClassNode node) {
+        String platform = context.getProperty(BuiltinProperties.PLATFORM_NAME);
         if (platform == null) {
-            Logger.debug("Skipping TransformPlatformOnly because BuiltinProperties.PLATFORM_NAME is not present");
+            context.getLogger().debug("Skipping TransformPlatformOnly because BuiltinProperties.PLATFORM_NAME is not present");
             return node;
         }
         

--- a/src/main/java/dev/architectury/transformer/transformers/base/ClassEditTransformer.java
+++ b/src/main/java/dev/architectury/transformer/transformers/base/ClassEditTransformer.java
@@ -24,15 +24,16 @@
 package dev.architectury.transformer.transformers.base;
 
 import dev.architectury.transformer.Transformer;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 import org.objectweb.asm.tree.ClassNode;
 
 public interface ClassEditTransformer extends Transformer {
-    ClassNode doEdit(String name, ClassNode node);
+    ClassNode doEdit(TransformerContext context, String name, ClassNode node);
     
-    default ClassNode doEdit(String name, ClassNode node, Options options) {
+    default ClassNode doEdit(TransformerContext context, String name, ClassNode node, Options options) {
         options.computeMaxs();
         options.computeFrames();
-        return doEdit(name, node);
+        return doEdit(context, name, node);
     }
     
     interface Options {

--- a/src/main/java/dev/architectury/transformer/transformers/base/TinyRemapperTransformer.java
+++ b/src/main/java/dev/architectury/transformer/transformers/base/TinyRemapperTransformer.java
@@ -25,9 +25,10 @@ package dev.architectury.transformer.transformers.base;
 
 import dev.architectury.tinyremapper.IMappingProvider;
 import dev.architectury.transformer.Transformer;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 
 import java.util.List;
 
 public interface TinyRemapperTransformer extends Transformer {
-    List<IMappingProvider> collectMappings() throws Exception;
+    List<IMappingProvider> collectMappings(TransformerContext context) throws Exception;
 }

--- a/src/main/java/dev/architectury/transformer/transformers/base/edit/SimpleTransformerContext.java
+++ b/src/main/java/dev/architectury/transformer/transformers/base/edit/SimpleTransformerContext.java
@@ -23,6 +23,11 @@
 
 package dev.architectury.transformer.transformers.base.edit;
 
+import dev.architectury.transformer.transformers.BuiltinProperties;
+import dev.architectury.transformer.util.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public final class SimpleTransformerContext implements TransformerContext {
@@ -30,31 +35,73 @@ public final class SimpleTransformerContext implements TransformerContext {
     private final boolean canModifyAssets;
     private final boolean canAppendArgument;
     private final boolean canAddClasses;
-    
-    public SimpleTransformerContext(Consumer<String[]> appendArgument, boolean canModifyAssets, boolean canAppendArgument, boolean canAddClasses) {
+    private final Map<String, String> properties;
+    private final Logger logger;
+
+    @Deprecated
+    public SimpleTransformerContext(
+        Consumer<String[]> appendArgument,
+        boolean canModifyAssets,
+        boolean canAppendArgument,
+        boolean canAddClasses
+    ) {
+        this(appendArgument, canModifyAssets, canAppendArgument, canAddClasses, null);
+    }
+
+    public SimpleTransformerContext(
+        Consumer<String[]> appendArgument,
+        boolean canModifyAssets,
+        boolean canAppendArgument,
+        boolean canAddClasses,
+        Map<String, String> properties
+    ) {
         this.appendArgument = appendArgument;
         this.canModifyAssets = canModifyAssets;
         this.canAppendArgument = canAppendArgument;
         this.canAddClasses = canAddClasses;
+        this.properties = new HashMap<>();
+        for (String key : BuiltinProperties.KEYS) {
+            String value = System.getProperty(key);
+            if (value != null) {
+                properties.put(key, value);
+            }
+        }
+        if (properties != null) {
+            this.properties.putAll(properties);
+        }
+        this.logger = new Logger(
+            getProperty(BuiltinProperties.LOCATION, System.getProperty("user.dir")),
+            getProperty(BuiltinProperties.VERBOSE, "false").equals("true")
+        );
     }
-    
+
     @Override
     public void appendArgument(String... args) {
         appendArgument.accept(args);
     }
-    
+
     @Override
     public boolean canModifyAssets() {
         return canModifyAssets;
     }
-    
+
     @Override
     public boolean canAppendArgument() {
         return canAppendArgument;
     }
-    
+
     @Override
     public boolean canAddClasses() {
         return canAddClasses;
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return properties.get(key);
+    }
+
+    @Override
+    public Logger getLogger() {
+        return logger;
     }
 }

--- a/src/main/java/dev/architectury/transformer/transformers/base/edit/TransformerContext.java
+++ b/src/main/java/dev/architectury/transformer/transformers/base/edit/TransformerContext.java
@@ -23,6 +23,8 @@
 
 package dev.architectury.transformer.transformers.base.edit;
 
+import dev.architectury.transformer.util.Logger;
+
 public interface TransformerContext {
     void appendArgument(String... args);
     
@@ -31,4 +33,13 @@ public interface TransformerContext {
     boolean canAppendArgument();
     
     boolean canAddClasses();
+
+    String getProperty(String key);
+
+    default String getProperty(String key, String defaultValue) {
+        String value = getProperty(key);
+        return value == null ? defaultValue : value;
+    }
+
+    Logger getLogger();
 }

--- a/src/main/java/dev/architectury/transformer/transformers/classpath/ReadClasspathProvider.java
+++ b/src/main/java/dev/architectury/transformer/transformers/classpath/ReadClasspathProvider.java
@@ -24,10 +24,11 @@
 package dev.architectury.transformer.transformers.classpath;
 
 import dev.architectury.transformer.transformers.ClasspathProvider;
+import dev.architectury.transformer.util.Logger;
 
 public interface ReadClasspathProvider {
-    static ReadClasspathProvider of(ClasspathProvider provider) {
-        return new ReadClasspathProviderImpl(provider.logging());
+    static ReadClasspathProvider of(Logger logger, ClasspathProvider provider) {
+        return new ReadClasspathProviderImpl(logger, provider.logging(logger));
     }
     
     byte[][] provide();

--- a/src/main/java/dev/architectury/transformer/transformers/classpath/ReadClasspathProviderImpl.java
+++ b/src/main/java/dev/architectury/transformer/transformers/classpath/ReadClasspathProviderImpl.java
@@ -26,6 +26,7 @@ package dev.architectury.transformer.transformers.classpath;
 import dev.architectury.transformer.Transform;
 import dev.architectury.transformer.input.MemoryFileAccess;
 import dev.architectury.transformer.transformers.ClasspathProvider;
+import dev.architectury.transformer.util.Logger;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -42,11 +43,13 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class ReadClasspathProviderImpl implements ReadClasspathProvider {
+    private final Logger logger;
     private final ClasspathProvider provider;
-    private Map<String, Integer> map = new HashMap<>();
+    private final Map<String, Integer> map = new HashMap<>();
     private byte[][] classpaths;
     
-    public ReadClasspathProviderImpl(ClasspathProvider provider) {
+    public ReadClasspathProviderImpl(Logger logger, ClasspathProvider provider) {
+        this.logger = logger;
         this.provider = provider;
     }
     
@@ -56,7 +59,7 @@ public class ReadClasspathProviderImpl implements ReadClasspathProvider {
             if (classpaths == null) {
                 map.clear();
                 try {
-                    Transform.logTime(() -> {
+                    Transform.logTime(logger, () -> {
                         ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
                         List<CompletableFuture<List<Map.Entry<String, byte[]>>>> futures = new ArrayList<>();
                         List<Closeable> fsToClose = Collections.synchronizedList(new ArrayList<>());

--- a/src/runtime/java/dev/architectury/transformer/ClassTransformerFileAccess.java
+++ b/src/runtime/java/dev/architectury/transformer/ClassTransformerFileAccess.java
@@ -62,7 +62,7 @@ public class ClassTransformerFileAccess implements ClassFileTransformer {
                 Transform.measureTime(() -> {
                     handler.handle(className + ".class", new Access(className, classBytes, originalSource), transformers);
                 }, duration -> {
-                    Logger.debug("Transformed " + className + " in " + formatDuration(duration));
+                    handler.getContext().getLogger().debug("Transformed " + className + " in " + formatDuration(duration));
                 });
                 if (debugOut != null) {
                     debugOut.addFile(className + ".class", classBytes.get());

--- a/src/runtime/java/dev/architectury/transformer/PathModifyListener.java
+++ b/src/runtime/java/dev/architectury/transformer/PathModifyListener.java
@@ -44,7 +44,7 @@ public class PathModifyListener extends Thread {
     @Override
     public void run() {
         try {
-            Logger.info("Listening at " + path);
+            Logger.getDefaultLogger().info("Listening at " + path);
             WatchService watcher = path.getFileSystem().newWatchService();
             try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
                 WatchKey watchKey = path.getParent().register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);


### PR DESCRIPTION
Passing arguments around using Java environment properties is unsafe and causes problems when building with architectury plugin with Gradle parallel build enabled. This moves all the properties into `TransformerContext`, since they are unique per transform task.
The `Logger` still has an old global access API just to keep things working. Same with `SimpleTransformerContext`, it still reads values from environment properties to maintain some compatibility. However, those should be replaced in the future. Some changes also have to be done on [architectury-plugin](https://github.com/architectury/architectury-plugin) to get it to work with these changes. There will be a pull request for it.