### PR TITLE
fix: don't delete temp file if windows

### DIFF
--- a/src/runtime/java/dev/architectury/transformer/TransformerRuntime.java
+++ b/src/runtime/java/dev/architectury/transformer/TransformerRuntime.java
@@ -175,7 +175,9 @@ public class TransformerRuntime {
                 try {
                     try (OpenedFileAccess outputInterface = OpenedFileAccess.ofJar(tmpJar)) {
                         Thread.sleep(4000);
-                        Files.deleteIfExists(tmpJar);
+                        if (!System.getProperty("os.name").startsWith("Windows")) {
+                            Files.deleteIfExists(tmpJar);
+                        }
                         try (OpenedFileAccess og = OpenedFileAccess.ofJar(entry.getPath())) {
                             og.copyTo(outputInterface);
                         }


### PR DESCRIPTION
Causes "The process cannot access the file because it is being used by another process" errors on Windows.