### PR TITLE
move the `PlatformMethods` generation from `TransformExpectPlatform` to `RemapInjectables`, where its used

### DIFF
--- a/src/main/java/dev/architectury/transformer/transformers/RemapInjectables.java
+++ b/src/main/java/dev/architectury/transformer/transformers/RemapInjectables.java
@@ -23,20 +23,24 @@
 
 package dev.architectury.transformer.transformers;
 
-import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
+import dev.architectury.transformer.input.FileAccess;
+import dev.architectury.transformer.transformers.base.AssetEditTransformer;
 import dev.architectury.transformer.transformers.base.ClassEditTransformer;
+import dev.architectury.transformer.transformers.base.edit.TransformerContext;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.ClassRemapper;
 import org.objectweb.asm.commons.Remapper;
 import org.objectweb.asm.tree.ClassNode;
 
-import java.io.File;
-
 /**
  * Remap architectury injectables calls to the injected classes.
  */
-public class RemapInjectables implements ClassEditTransformer {
+public class RemapInjectables implements AssetEditTransformer, ClassEditTransformer {
     public static final String EXPECT_PLATFORM_LEGACY = "Lme/shedaniel/architectury/ExpectPlatform;";
     public static final String EXPECT_PLATFORM_LEGACY2 = "Lme/shedaniel/architectury/annotations/ExpectPlatform;";
     public static final String EXPECT_PLATFORM = "Ldev/architectury/injectables/annotations/ExpectPlatform;";
@@ -44,43 +48,65 @@ public class RemapInjectables implements ClassEditTransformer {
     public static final String PLATFORM_ONLY_LEGACY = "Lme/shedaniel/architectury/annotations/PlatformOnly;";
     public static final String PLATFORM_ONLY = "Ldev/architectury/injectables/annotations/PlatformOnly;";
     private static final String ARCHITECTURY_TARGET = "dev/architectury/injectables/targets/ArchitecturyTarget";
-    private String uniqueIdentifier = null;
-    
+    private String uniqueIdentifier = getUniqueIdentifier() + "/PlatformMethods";
+
     @Override
     public void supplyProperties(JsonObject json) {
-        uniqueIdentifier = json.has(BuiltinProperties.UNIQUE_IDENTIFIER) ?
-                json.getAsJsonPrimitive(BuiltinProperties.UNIQUE_IDENTIFIER).getAsString() : null;
+        if (json.has(BuiltinProperties.UNIQUE_IDENTIFIER))
+            uniqueIdentifier = json.getAsJsonPrimitive(BuiltinProperties.UNIQUE_IDENTIFIER).getAsString() + "/PlatformMethods";
     }
-    
+
+    @Override
+    public void doEdit(TransformerContext context, FileAccess output) throws Exception {
+        if (!RemapInjectables.isInjectInjectables()) return;
+        output.addClass(uniqueIdentifier, buildPlatformMethodClass(uniqueIdentifier));
+    }
+
+    private byte[] buildPlatformMethodClass(String className) {
+        /* Generates the following class:
+         * public final class PlatformMethods {
+         *   public static String getCurrentTarget() {
+         *     return platform;
+         *   }
+         * }
+         */
+        String platform = System.getProperty(BuiltinProperties.PLATFORM_NAME);
+        Preconditions.checkNotNull(platform, BuiltinProperties.PLATFORM_NAME + " is not present!");
+
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL, className, null, "java/lang/Object", null);
+        {
+            MethodVisitor method = writer.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "getCurrentTarget", "()Ljava/lang/String;", null, null);
+            method.visitLdcInsn(platform);
+            method.visitInsn(Opcodes.ARETURN);
+            method.visitEnd();
+        }
+        writer.visitEnd();
+        return writer.toByteArray();
+    }
+
     @Override
     public ClassNode doEdit(String name, ClassNode node) {
         if (!isInjectInjectables()) return node; // no need to edit the class
-        String newName = MoreObjects.firstNonNull(uniqueIdentifier, getUniqueIdentifier()) + "/PlatformMethods";
         ClassNode newNode = new ClassNode();
         Remapper remapper = new Remapper() {
             @Override
             public String map(String internalName) {
-                if (ARCHITECTURY_TARGET.equals(internalName)) {
-                    return newName;
-                }
-                
-                return internalName;
+                return ARCHITECTURY_TARGET.equals(internalName) ? uniqueIdentifier : internalName;
+
             }
         };
         ClassVisitor cv = new ClassRemapper(newNode, remapper);
         node.accept(cv);
         return newNode;
     }
-    
+
     public static String getUniqueIdentifier() {
         return System.getProperty(BuiltinProperties.UNIQUE_IDENTIFIER);
     }
-    
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public static boolean isInjectInjectables() {
         return System.getProperty(BuiltinProperties.INJECT_INJECTABLES, "true").equals("true");
-    }
-    
-    public static String[] getClasspath() {
-        return System.getProperty(BuiltinProperties.COMPILE_CLASSPATH, "true").split(File.pathSeparator);
     }
 }


### PR DESCRIPTION
so that i dont have a completely useless `architectury_inject_blah_common_hashhashblahblah` thing in my jar

p.s.: i dont really know how i would test this, so please dont kill me if it doesnt work properly